### PR TITLE
Fix Dependency Issue For Standalone bl-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boklisten/bl-connect",
-	"version": "0.20.14",
+	"version": "0.20.15",
 	"license": "MIT",
 	"scripts": {
 		"dev": "yarn serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@boklisten/bl-connect",
-	"version": "0.20.10",
+	"version": "0.20.14",
 	"license": "MIT",
 	"scripts": {
 		"dev": "yarn serve",
@@ -17,7 +17,10 @@
 		"lib": {
 			"entryFile": "public_api.ts"
 		},
-		"dest": "./dist/@boklisten/bl-connect"
+		"dest": "./dist/@boklisten/bl-connect",
+		"whitelistedNonPeerDependencies": [
+			"@auth0/angular-jwt"
+		]
 	},
 	"$schema": "../../node_modules/ng-packagr/package.schema.json",
 	"private": false,
@@ -33,7 +36,6 @@
 		"@angular/language-service": "^11.1.2",
 		"@angular/platform-browser": "^11.1.2",
 		"@angular/platform-browser-dynamic": "^11.1.2",
-		"@auth0/angular-jwt": "^5.0.2",
 		"@boklisten/bl-model": "^0.25.37",
 		"@types/jasmine": "~3.6.3",
 		"@types/jasminewd2": "~2.0.8",
@@ -77,6 +79,7 @@
 	},
 	"homepage": "https://github.com/boklisten/bl-connect#readme",
 	"dependencies": {
-		"tslib": "^2.1.0"
+		"tslib": "^2.1.0",
+		"@auth0/angular-jwt": "5.0.2"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,7 +253,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@auth0/angular-jwt@^5.0.2":
+"@auth0/angular-jwt@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@auth0/angular-jwt/-/angular-jwt-5.0.2.tgz#0a23f240e8c6ed37c5c7a354ad79a755a217936e"
   integrity sha512-rSamC9mu+gUxoR86AXcIo+KD7xRIro+/iu1F2Ld85YAZEVKlpB5vYG+g0yGaEOqjtQWP/i0H6fi6XMGPVHSYYQ==
@@ -9989,8 +9989,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
The package auth0/angular-jwt is actually used by bl-connect, even though it is only in the devDependency list. This is not normally a problem, since _bl-login_ has that package installed, and bl-connect just steals its version when it is installed together with bl-login. As I work towards removing bl-login, this is problematic, as bl-connect actually need this, but it is not available in the consumer package unless bl-login is _also_ installed. Thus, we need to include it in the dependency list...
